### PR TITLE
feat: add CV page and refactor CSS into external files

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -5,6 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Soojin Jung — CV</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
     <link rel="stylesheet" href="styles/common.css" />
     <link rel="stylesheet" href="styles/cv.css" />
   </head>

--- a/cv.html
+++ b/cv.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Soojin Jung — CV</title>
+    <link rel="stylesheet" href="styles/common.css" />
+    <link rel="stylesheet" href="styles/cv.css" />
+  </head>
+
+  <body>
+    <div class="cv-container">
+      <a class="back-link" href="index.html">&larr; Back to profile</a>
+
+      <!-- Header -->
+      <header class="cv-header">
+        <h1>Soojin Jung</h1>
+        <p class="title">Software Engineer</p>
+        <div class="contact">
+          <span>sojjung3@gmail.com</span>
+          <a href="https://github.com/soojjung" target="_blank">GitHub</a>
+          <a href="https://www.linkedin.com/in/soo-jin-jung" target="_blank">LinkedIn</a>
+          <a href="https://medium.com/@sojjung3" target="_blank">Medium</a>
+        </div>
+      </header>
+
+      <!-- About -->
+      <section class="cv-section">
+        <h2>About</h2>
+        <p class="about-text">
+          Frontend developer with 3+ years of experience building production-grade web applications in fintech and AI domains. Skilled at architecting scalable component systems and integrating complex backend/AI services into intuitive user interfaces. Recently expanded into backend and AI engineering to deliver end-to-end solutions.
+        </p>
+      </section>
+
+      <!-- Education -->
+      <section class="cv-section">
+        <h2>Education</h2>
+
+        <div class="timeline-item">
+          <h3>BSc. in Applied Mathematics and Statistics &amp; Economics</h3>
+          <p class="company">Stony Brook, State University of New York — 3.57 GPA</p>
+          <p class="period">Graduated Dec 2018</p>
+        </div>
+
+        <div class="timeline-item">
+          <h3>Backend &amp; AI Engineering Bootcamp</h3>
+          <p class="company">FastCampus K-Digital Training</p>
+          <p class="period">Jun 2025 — Dec 2025</p>
+        </div>
+      </section>
+
+      <!-- Skills -->
+      <section class="cv-section">
+        <h2>Skills</h2>
+        <div class="skills-grid">
+          <div class="skill-category">
+            <h3>Frontend</h3>
+            <div class="skill-tags">
+              <span class="skill-tag">TypeScript</span>
+              <span class="skill-tag">React</span>
+              <span class="skill-tag">Next.js</span>
+              <span class="skill-tag">Zustand</span>
+              <span class="skill-tag">TanStack Query</span>
+            </div>
+          </div>
+          <div class="skill-category">
+            <h3>Backend &amp; Infra</h3>
+            <div class="skill-tags">
+              <span class="skill-tag">Spring Boot</span>
+              <span class="skill-tag">FastAPI</span>
+              <span class="skill-tag">MySQL</span>
+              <span class="skill-tag">AWS</span>
+              <span class="skill-tag">Docker</span>
+            </div>
+          </div>
+          <div class="skill-category">
+            <h3>AI / ML</h3>
+            <div class="skill-tags">
+              <span class="skill-tag">LangChain</span>
+              <span class="skill-tag">RAG</span>
+              <span class="skill-tag">OpenAI API</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Work Experience -->
+      <section class="cv-section">
+        <h2>Work Experience</h2>
+
+        <div class="timeline-item">
+          <h3>Frontend Developer</h3>
+          <p class="company">BeHappy</p>
+          <p class="period">Oct 2024 — May 2025</p>
+          <ul class="description">
+            <li>Built an AI-powered mobile finance service with real-time chatbot using SSE and OpenAI Whisper (&lt;500ms latency).</li>
+            <li>Engineered a 4-tier data persistence strategy (Recoil + localStorage) managing 310+ dynamic fields with zero data loss.</li>
+            <li>Led a data-driven product pivot using GA4/Mixpanel, uncovering 95% mobile access rate.</li>
+          </ul>
+        </div>
+
+        <div class="timeline-item">
+          <h3>Frontend Developer</h3>
+          <p class="company">aiZENGlobal</p>
+          <p class="period">Mar 2022 — Jun 2024</p>
+          <ul class="description">
+            <li>Architected a tri-portal loan brokerage platform (Customer, Operations, Financial Partners) from the ground up.</li>
+            <li>Built 99+ reusable UI components and a config-based SearchTable pattern, reducing dev time by 60% across 30+ pages.</li>
+            <li>Implemented JWT auto-renewal with Request Queue pattern and 8-stage auth flow for financial data security.</li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- Projects -->
+      <section class="cv-section">
+        <h2>Projects</h2>
+
+        <div class="project-item">
+          <h3><a href="https://github.com/soojjung/bbumate-ai" target="_blank">RAG-based AI Policy Assistant</a></h3>
+          <p class="project-period">Aug 2025 — Nov 2025</p>
+          <ul class="project-desc">
+            <li>Built an end-to-end RAG pipeline (LangChain + ChromaDB) centralizing 113+ policies; reduced latency 66% via parallel document grading.</li>
+            <li>Engineered a multi-step fallback strategy (RAG &rarr; Query Re-write &rarr; Web Search) achieving 100% query fulfillment.</li>
+          </ul>
+          <div class="project-tech">
+            <span>LangChain</span>
+            <span>ChromaDB</span>
+            <span>RAG</span>
+            <span>Python</span>
+          </div>
+        </div>
+
+        <div class="project-item">
+          <h3><a href="https://github.com/soojjung/GOTCHA-FE" target="_blank">Gacha Shop Map Service</a></h3>
+          <p class="project-period">Nov 2025 — Present</p>
+          <ul class="project-desc">
+            <li>Architected a 3-layer architecture with Container/Presenter pattern; hybrid state management (TanStack Query + Zustand) across 21 API hooks.</li>
+            <li>Optimized geospatial performance reducing API overhead by 80% and component complexity by 44%.</li>
+          </ul>
+          <div class="project-tech">
+            <span>React</span>
+            <span>TypeScript</span>
+            <span>Zustand</span>
+            <span>TanStack Query</span>
+          </div>
+        </div>
+
+        <div class="project-item">
+          <h3><a href="https://github.com/soojjung/OppaManyColorTone" target="_blank">Personal Color Self-Diagnosis Service</a></h3>
+          <p class="project-period">Feb 2023 — Aug 2024</p>
+          <ul class="project-desc">
+            <li>Scaled to 77,900+ diagnoses and 27,600+ AAU with 91.5% completion rate.</li>
+            <li>Achieved 83% organic traffic (30,000+ sessions) via SEO/SSR optimization, ranking on Google's first page.</li>
+          </ul>
+          <div class="project-tech">
+            <span>React</span>
+            <span>Next.js</span>
+            <span>Recoil</span>
+            <span>SEO</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Additional -->
+      <section class="cv-section">
+        <h2>Additional</h2>
+        <ul class="additional-list">
+          <li>Staff Member, TeoConf 2024 (3rd Edition) — Coordinated event logistics and attendee (200+) engagement</li>
+          <li>Google Analytics Certification (GA4)</li>
+        </ul>
+      </section>
+    </div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
     <meta property="og:description" content="Software Engineer" />
     <meta property="og:image" content="images/pink_notebook.jpg" />
     <title>Soojin Jung Profile</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@500&display=swap" />
     <link rel="stylesheet" href="styles/common.css" />
     <link rel="stylesheet" href="styles/index.css" />
   </head>

--- a/index.html
+++ b/index.html
@@ -1,129 +1,28 @@
-<!DOCTYPE html>
-<html lang="ko">
+<!doctype html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta property="og:title" content="정수진 프로필" />
-    <meta property="og:description" content="Frontend Developer" />
+    <meta property="og:title" content="Soojin Jung Profile" />
+    <meta property="og:description" content="Software Engineer" />
     <meta property="og:image" content="images/pink_notebook.jpg" />
-    <title>정수진 프로필</title>
-    <style>
-      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@500&display=swap");
-
-      :root {
-        --pink-main: #fadadd;
-        --pink-light: #ffe4e1;
-        --pink-accent: #f8c8dc;
-        --lavender: #e6e6fa;
-        --white: #ffffff;
-        --bg: #333333;
-        --btn-bg: #444;
-        --btn-border: #555;
-        --btn-text: #fff;
-        --font-sans: 'Inter', sans-serif;
-      }
-
-      * {
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-        font-family: var(--font-sans);
-      }
-
-      body {
-        background-color: var(--bg);
-        min-height: 100vh;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        padding: 2rem;
-      }
-
-      .wrap {
-        display: flex;
-        flex-direction: column;
-        gap: 16px;
-        width: 320px;
-        align-items: center;
-      }
-
-      .profile {
-        width: 128px;
-        height: 128px;
-        border-radius: 50%;
-        background-image: url("/images/pink_notebook.jpg");
-        background-position: center;
-        background-size: cover;
-        border: 2px solid var(--pink-main);
-        margin-bottom: 10px;
-      }
-
-      .main {
-        font-size: 22px;
-        color: var(--pink-main);
-        font-weight: bold;
-      }
-
-      .sub {
-        font-size: 14px;
-        color: #bbbbbb;
-        margin-bottom: 36px;
-      }
-
-      a.button-wrap {
-        background-color: var(--btn-bg);
-        border-radius: 32px;
-        padding: 12px 24px;
-        color: var(--btn-text);
-        font-weight: 500;
-        font-size: 15px;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        border: 1px solid var(--btn-border);
-        box-shadow: inset 0 1px 1px rgba(255,255,255,0.1);
-        letter-spacing: 0.3px;
-        transition: background 0.3s ease;
-        cursor: pointer;
-        width: 100%;
-        text-decoration: none;
-      }
-
-      a.button-wrap:hover {
-        background-color: #555;
-      }
-
-      .icon {
-        font-size: 18px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 24px;
-      }
-
-      .button-wrap span:nth-child(2) {
-        flex: 1;
-        text-align: center;
-      }
-
-      .dots {
-        font-size: 18px;
-        margin-bottom: 10px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-    </style>
+    <title>Soojin Jung Profile</title>
+    <link rel="stylesheet" href="styles/common.css" />
+    <link rel="stylesheet" href="styles/index.css" />
   </head>
 
   <body>
     <div class="wrap">
       <div class="profile"></div>
       <h1 class="main">Soojin Jung</h1>
-      <p class="sub">Frontend Developer</p>
+      <p class="sub">Software Engineer</p>
 
-      <a class="button-wrap" href="https://www.linkedin.com/in/soojin-jung-313191284/" target="_blank">
+      <a
+        class="button-wrap"
+        href="https://www.linkedin.com/in/soojin-jung-313191284/"
+        target="_blank"
+      >
         <span class="icon">🎧</span>
         <span>linkedin</span>
         <span class="dots">...</span>
@@ -133,14 +32,18 @@
         <span>github</span>
         <span class="dots">...</span>
       </a>
-      <a class="button-wrap" href="https://medium.com/@sojjung3" target="_blank">
+      <a
+        class="button-wrap"
+        href="https://medium.com/@sojjung3"
+        target="_blank"
+      >
         <span class="icon">🫧</span>
         <span>medium</span>
         <span class="dots">...</span>
       </a>
-      <a class="button-wrap" href="https://www.instagram.com/soojjnng" target="_blank">
-        <span class="icon">♥</span>
-        <span>instagram</span>
+      <a class="button-wrap" href="cv.html" target="_blank">
+        <span class="icon">📧</span>
+        <span>cv / resume</span>
         <span class="dots">...</span>
       </a>
     </div>

--- a/styles/common.css
+++ b/styles/common.css
@@ -1,0 +1,8 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: var(--font-sans);
+}

--- a/styles/common.css
+++ b/styles/common.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
-
 * {
   margin: 0;
   padding: 0;

--- a/styles/cv.css
+++ b/styles/cv.css
@@ -1,0 +1,341 @@
+:root {
+  --accent: #e8a0b4;
+  --accent-dark: #d4768e;
+  --bg: #f7f7f7;
+  --card-bg: #ffffff;
+  --text-primary: #333333;
+  --text-secondary: #555555;
+  --text-muted: #888888;
+  --border: #e0e0e0;
+  --font-sans: "Inter", sans-serif;
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--text-primary);
+  line-height: 1.6;
+  padding: 2rem 1rem;
+}
+
+.cv-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.back-link {
+  display: inline-block;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 14px;
+  margin-bottom: 1.5rem;
+  transition: opacity 0.2s;
+}
+
+.back-link:hover {
+  opacity: 0.7;
+}
+
+/* Header */
+.cv-header {
+  text-align: center;
+  padding-bottom: 2rem;
+  margin-bottom: 2rem;
+  border-bottom: 2px solid var(--accent);
+}
+
+.cv-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.25rem;
+}
+
+.cv-header .title {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+}
+
+.cv-header .contact {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.cv-header .contact a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.cv-header .contact a:hover {
+  text-decoration: underline;
+}
+
+/* Sections */
+.cv-section {
+  margin-bottom: 2.5rem;
+}
+
+.cv-section h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+/* About */
+.about-text {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.additional-list {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-left: 1rem;
+}
+
+/* Timeline items (Experience, Education) */
+.timeline-item {
+  position: relative;
+  padding-left: 1.25rem;
+  margin-bottom: 1.5rem;
+  border-left: 2px solid var(--accent);
+}
+
+.timeline-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: -5px;
+  top: 6px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--accent);
+}
+
+.timeline-item h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.timeline-item .company {
+  font-size: 0.9rem;
+  color: var(--accent-dark);
+  margin-bottom: 0.25rem;
+}
+
+.timeline-item .period {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.timeline-item .description {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.timeline-item .description li {
+  margin-bottom: 0.25rem;
+  margin-left: 1rem;
+}
+
+/* Skills */
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.skill-category h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.skill-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.skill-tag {
+  background-color: var(--card-bg);
+  color: var(--text-secondary);
+  padding: 0.25rem 0.75rem;
+  border-radius: 16px;
+  font-size: 0.8rem;
+  border: 1px solid var(--border);
+}
+
+/* Projects */
+.project-item {
+  background-color: var(--card-bg);
+  border-radius: 8px;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--border);
+}
+
+.project-item:last-child {
+  margin-bottom: 0;
+}
+
+.project-item h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.25rem;
+}
+
+.project-item h3 a {
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.project-item h3 a:hover {
+  text-decoration: underline;
+}
+
+.project-item .project-period {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.project-item .project-desc {
+  list-style: disc;
+  padding-left: 1.25rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.project-item .project-desc li {
+  margin-bottom: 0.25rem;
+}
+
+.project-item .project-tech {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.project-item .project-tech span {
+  background-color: var(--bg);
+  color: var(--accent-dark);
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+}
+
+/* Print */
+@media print {
+  body {
+    background-color: #fff;
+    color: #222;
+    padding: 0;
+  }
+
+  .back-link {
+    display: none;
+  }
+
+  .cv-container {
+    max-width: 100%;
+  }
+
+  .cv-header h1 {
+    color: #222;
+  }
+
+  .cv-header .title {
+    color: #555;
+  }
+
+  .cv-header .contact,
+  .cv-header .contact a {
+    color: #555;
+  }
+
+  .cv-header {
+    border-bottom-color: #ccc;
+  }
+
+  .cv-section h2 {
+    color: #555;
+    border-bottom-color: #ddd;
+  }
+
+  .about-text,
+  .timeline-item .description,
+  .project-item .project-desc {
+    color: #333;
+  }
+
+  .timeline-item {
+    border-left-color: #ccc;
+  }
+
+  .timeline-item::before {
+    background-color: #ccc;
+  }
+
+  .timeline-item h3,
+  .skill-category h3,
+  .project-item h3 {
+    color: #222;
+  }
+
+  .timeline-item .company,
+  .timeline-item .period,
+  .project-item .project-period {
+    color: #666;
+  }
+
+  .skill-tag {
+    background-color: #f5f5f5;
+    color: #333;
+    border-color: #ddd;
+  }
+
+  .project-item {
+    background-color: #f9f9f9;
+    border-color: #ddd;
+  }
+
+  .project-item .project-tech span {
+    background-color: #eee;
+    color: #555;
+  }
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .cv-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .cv-header .contact {
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  .skills-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -86,6 +86,7 @@ a.button-wrap:hover {
 
 .dots {
   font-size: 18px;
+  margin-bottom: 10px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,0 +1,92 @@
+:root {
+  --accent: #fadadd;
+  --bg: #333333;
+  --sub-text: #bbbbbb;
+  --btn-bg: #444;
+  --btn-border: #555;
+  --btn-text: #fff;
+  --font-sans: "Inter", sans-serif;
+}
+
+body {
+  background-color: var(--bg);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 320px;
+  align-items: center;
+}
+
+.profile {
+  width: 128px;
+  height: 128px;
+  border-radius: 50%;
+  background-image: url("/images/pink_notebook.jpg");
+  background-position: center;
+  background-size: cover;
+  border: 2px solid var(--accent);
+  margin-bottom: 10px;
+}
+
+.main {
+  font-size: 22px;
+  color: var(--accent);
+  font-weight: bold;
+}
+
+.sub {
+  font-size: 14px;
+  color: var(--sub-text);
+  margin-bottom: 36px;
+}
+
+a.button-wrap {
+  background-color: var(--btn-bg);
+  border-radius: 32px;
+  padding: 12px 24px;
+  color: var(--btn-text);
+  font-weight: 500;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--btn-border);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.1);
+  letter-spacing: 0.3px;
+  transition: background 0.3s ease;
+  cursor: pointer;
+  width: 100%;
+  text-decoration: none;
+}
+
+a.button-wrap:hover {
+  background-color: #555;
+}
+
+.icon {
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+}
+
+.button-wrap span:nth-child(2) {
+  flex: 1;
+  text-align: center;
+}
+
+.dots {
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
- Replace Instagram button with CV/Resume link
- Add cv.html with resume content (experience, education, skills, projects)
- Extract inline styles into styles/common.css, styles/index.css, styles/cv.css
- Update title to Software Engineer, switch lang to English
- Clean up unused CSS variables and fix og:description

<img width="854" height="878" alt="스크린샷 2026-03-25 오후 6 26 06" src="https://github.com/user-attachments/assets/c8eff57a-a2e1-4d66-b989-7b4f59d6a852" />
