### PR TITLE
feat: add Korean CV with language toggle, PDF download, and content updates

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -8,81 +8,90 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
     <link rel="stylesheet" href="styles/common.css" />
     <link rel="stylesheet" href="styles/cv.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.2/html2pdf.bundle.min.js"></script>
   </head>
 
   <body>
     <div class="cv-container">
-      <a class="back-link" href="index.html">&larr; Back to profile</a>
+      <div class="cv-top-bar">
+        <a class="back-link" href="index.html">&larr; <span data-lang-en>Back to profile</span><span data-lang-ko>프로필로 돌아가기</span></a>
+        <div class="top-bar-actions">
+          <button class="btn-pill" onclick="downloadPdf()" aria-label="Download PDF">
+            <span data-lang-en>PDF</span><span data-lang-ko>PDF</span> &darr;
+          </button>
+          <button class="btn-pill" onclick="toggleLang()" aria-label="Toggle language">
+            <span data-lang-en>KO</span><span data-lang-ko>EN</span>
+          </button>
+        </div>
+      </div>
 
       <!-- Header -->
       <header class="cv-header">
-        <h1>Soojin Jung</h1>
-        <p class="title">Software Engineer</p>
+        <h1><span data-lang-en>Soojin Jung</span><span data-lang-ko>정수진</span></h1>
+        <p class="title"><span data-lang-en>Software Engineer</span><span data-lang-ko>소프트웨어 엔지니어</span></p>
         <div class="contact">
           <span>sojjung3@gmail.com</span>
-          <a href="https://github.com/soojjung" target="_blank">GitHub</a>
-          <a href="https://www.linkedin.com/in/soo-jin-jung" target="_blank">LinkedIn</a>
-          <a href="https://medium.com/@sojjung3" target="_blank">Medium</a>
+          <span class="dot">·</span>
+          <a href="https://github.com/soojjung" target="_blank">github.com/soojjung</a>
+          <a href="https://www.linkedin.com/in/soo-jin-jung" target="_blank">linkedin.com/in/soo-jin-jung</a>
+          <span class="dot">·</span>
+          <a href="https://medium.com/@sojjung3" target="_blank">medium.com/@sojjung3</a>
         </div>
       </header>
 
       <!-- About -->
       <section class="cv-section">
-        <h2>About</h2>
+        <h2><span data-lang-en>About</span><span data-lang-ko>소개</span></h2>
         <p class="about-text">
-          Frontend developer with 3+ years of experience building production-grade web applications in fintech and AI domains. Skilled at architecting scalable component systems and integrating complex backend/AI services into intuitive user interfaces. Recently expanded into backend and AI engineering to deliver end-to-end solutions.
+          <span data-lang-en>3+ years of frontend development experience building production-grade web applications in fintech and AI domains. Skilled at architecting scalable component systems and integrating complex backend/AI services into intuitive user interfaces. Passionate about data-driven decision making, having led product pivots through GA4/Mixpanel analytics and established code review processes that measurably improved quality. Recently expanded into backend and AI engineering — building RAG pipelines, REST APIs, and CI/CD workflows — to deliver end-to-end solutions.</span>
+          <span data-lang-ko>핀테크 및 AI 분야에서 3년 이상의 프론트엔드 개발 경험을 바탕으로 프로덕션급 웹 애플리케이션을 구축해 왔습니다. 확장 가능한 컴포넌트 시스템 설계와 복잡한 백엔드/AI 서비스를 직관적인 사용자 인터페이스로 통합하는 데 강점이 있습니다. GA4/Mixpanel 분석을 통한 데이터 기반 의사결정과 코드 리뷰 프로세스 도입으로 품질을 개선한 경험이 있습니다. 최근 백엔드 및 AI 엔지니어링으로 영역을 확장하여 RAG 파이프라인, REST API, CI/CD 워크플로우 등 엔드투엔드 솔루션을 제공하고 있습니다.</span>
         </p>
-      </section>
-
-      <!-- Education -->
-      <section class="cv-section">
-        <h2>Education</h2>
-
-        <div class="timeline-item">
-          <h3>BSc. in Applied Mathematics and Statistics &amp; Economics</h3>
-          <p class="company">Stony Brook, State University of New York — 3.57 GPA</p>
-          <p class="period">Graduated Dec 2018</p>
-        </div>
-
-        <div class="timeline-item">
-          <h3>Backend &amp; AI Engineering Bootcamp</h3>
-          <p class="company">FastCampus K-Digital Training</p>
-          <p class="period">Jun 2025 — Dec 2025</p>
-        </div>
       </section>
 
       <!-- Skills -->
       <section class="cv-section">
-        <h2>Skills</h2>
-        <div class="skills-grid">
-          <div class="skill-category">
-            <h3>Frontend</h3>
+        <h2><span data-lang-en>Skills</span><span data-lang-ko>기술 스택</span></h2>
+        <div class="skills-list">
+          <div class="skill-row">
+            <h3><span data-lang-en>Frontend</span><span data-lang-ko>프론트엔드</span></h3>
             <div class="skill-tags">
               <span class="skill-tag">TypeScript</span>
               <span class="skill-tag">React</span>
               <span class="skill-tag">Next.js</span>
               <span class="skill-tag">Zustand</span>
               <span class="skill-tag">TanStack Query</span>
+              <span class="skill-tag">Tailwind CSS</span>
             </div>
           </div>
-          <div class="skill-category">
-            <h3>Backend &amp; Infra</h3>
+          <div class="skill-row">
+            <h3><span data-lang-en>Backend &amp; Infra</span><span data-lang-ko>백엔드 &amp; 인프라</span></h3>
             <div class="skill-tags">
+              <span class="skill-tag">Java</span>
+              <span class="skill-tag">Python</span>
               <span class="skill-tag">Spring Boot</span>
               <span class="skill-tag">FastAPI</span>
-              <span class="skill-tag">MySQL</span>
-              <span class="skill-tag">AWS</span>
+              <span class="skill-tag">PostgreSQL</span>
               <span class="skill-tag">Docker</span>
             </div>
           </div>
-          <div class="skill-category">
+          <div class="skill-row">
             <h3>AI / ML</h3>
             <div class="skill-tags">
-              <span class="skill-tag">LangChain</span>
-              <span class="skill-tag">RAG</span>
               <span class="skill-tag">OpenAI API</span>
+              <span class="skill-tag">LangChain</span>
+              <span class="skill-tag">ChromaDB</span>
+              <span class="skill-tag">RAG</span>
+            </div>
+          </div>
+          <div class="skill-row">
+            <h3>Tools</h3>
+            <div class="skill-tags">
+              <span class="skill-tag">AWS</span>
+              <span class="skill-tag">Google Analytics</span>
+              <span class="skill-tag">GitHub Actions</span>
             </div>
           </div>
         </div>
@@ -90,89 +99,232 @@
 
       <!-- Work Experience -->
       <section class="cv-section">
-        <h2>Work Experience</h2>
+        <h2><span data-lang-en>Work Experience</span><span data-lang-ko>경력</span></h2>
 
         <div class="timeline-item">
-          <h3>Frontend Developer</h3>
+          <h3><span data-lang-en>Frontend Developer</span><span data-lang-ko>프론트엔드 개발자</span></h3>
           <p class="company">BeHappy</p>
-          <p class="period">Oct 2024 — May 2025</p>
+          <p class="period"><span data-lang-en>Oct 2024 — May 2025</span><span data-lang-ko>2024년 10월 — 2025년 5월</span></p>
           <ul class="description">
-            <li>Built an AI-powered mobile finance service with real-time chatbot using SSE and OpenAI Whisper (&lt;500ms latency).</li>
-            <li>Engineered a 4-tier data persistence strategy (Recoil + localStorage) managing 310+ dynamic fields with zero data loss.</li>
-            <li>Led a data-driven product pivot using GA4/Mixpanel, uncovering 95% mobile access rate.</li>
+            <li>
+              <span data-lang-en>Built an AI-powered mobile finance service with real-time chatbot using SSE and OpenAI Whisper (&lt;500ms latency).</span>
+              <span data-lang-ko>SSE와 OpenAI Whisper를 활용한 실시간 챗봇 기반 AI 모바일 금융 서비스 구축 (500ms 미만 지연시간)</span>
+            </li>
+            <li>
+              <span data-lang-en>Implemented Zod schema validation for AI chatbot data integrity, reducing runtime errors and ensuring type-safe communication across 310+ dynamic fields.</span>
+              <span data-lang-ko>AI 챗봇 데이터 무결성을 위한 Zod 스키마 검증 도입, 310개 이상 동적 필드에서 런타임 에러 감소 및 타입 안전 통신 확보</span>
+            </li>
+            <li>
+              <span data-lang-en>Drove a data-driven product pivot using GA4/Mixpanel analytics, discovering 60+ age user segment and 95% mobile access rate — directly shaping the mobile-first UX strategy.</span>
+              <span data-lang-ko>GA4/Mixpanel 분석으로 60대 이상 사용자 세그먼트 및 95% 모바일 접속률 발견, 모바일 퍼스트 UX 전략 수립 주도</span>
+            </li>
           </ul>
+          <div class="project-tech">
+            <span>React</span>
+            <span>JavaScript</span>
+            <span>Recoil</span>
+            <span>Tailwind CSS</span>
+            <span>Zod</span>
+            <span>GitHub Actions</span>
+          </div>
         </div>
 
         <div class="timeline-item">
-          <h3>Frontend Developer</h3>
+          <h3><span data-lang-en>Frontend Developer</span><span data-lang-ko>프론트엔드 개발자</span></h3>
           <p class="company">aiZENGlobal</p>
-          <p class="period">Mar 2022 — Jun 2024</p>
+          <p class="period"><span data-lang-en>Mar 2022 — Jun 2024</span><span data-lang-ko>2022년 3월 — 2024년 6월</span></p>
           <ul class="description">
-            <li>Architected a tri-portal loan brokerage platform (Customer, Operations, Financial Partners) from the ground up.</li>
-            <li>Built 99+ reusable UI components and a config-based SearchTable pattern, reducing dev time by 60% across 30+ pages.</li>
-            <li>Implemented JWT auto-renewal with Request Queue pattern and 8-stage auth flow for financial data security.</li>
+            <li>
+              <span data-lang-en>Architected a React 18 SPA tri-portal loan brokerage platform (Customer, Operations, Financial Partners) from the ground up.</span>
+              <span data-lang-ko>React 18 SPA 기반 고객·운영·금융 파트너 3개 포탈 대출 중개 플랫폼 설계 및 구축</span>
+            </li>
+            <li>
+              <span data-lang-en>Built 99+ reusable UI components and a config-based SearchTable pattern, reducing dev time by 60% across 30+ pages.</span>
+              <span data-lang-ko>99개 이상 재사용 가능한 UI 컴포넌트 및 설정 기반 SearchTable 패턴 구축, 30개 이상 페이지에서 개발 시간 60% 단축</span>
+            </li>
+            <li>
+              <span data-lang-en>Established code review process that cut QA bug defects by 50% and reduced maintenance effort by 70%; implemented JWT auto-renewal with Request Queue pattern for financial data security.</span>
+              <span data-lang-ko>코드 리뷰 프로세스 도입으로 QA 버그 결함 50% 감소 및 유지보수 공수 70% 절감, Request Queue 패턴 기반 JWT 자동 갱신으로 금융 데이터 보안 강화</span>
+            </li>
           </ul>
+          <div class="project-tech">
+            <span>React</span>
+            <span>JavaScript</span>
+            <span>Context API</span>
+            <span>Styled-components</span>
+          </div>
         </div>
       </section>
 
       <!-- Projects -->
-      <section class="cv-section">
-        <h2>Projects</h2>
+      <section class="cv-section cv-section-projects">
+        <h2><span data-lang-en>Projects</span><span data-lang-ko>프로젝트</span></h2>
 
-        <div class="project-item">
-          <h3><a href="https://github.com/soojjung/bbumate-ai" target="_blank">RAG-based AI Policy Assistant</a></h3>
-          <p class="project-period">Aug 2025 — Nov 2025</p>
-          <ul class="project-desc">
-            <li>Built an end-to-end RAG pipeline (LangChain + ChromaDB) centralizing 113+ policies; reduced latency 66% via parallel document grading.</li>
-            <li>Engineered a multi-step fallback strategy (RAG &rarr; Query Re-write &rarr; Web Search) achieving 100% query fulfillment.</li>
-          </ul>
-          <div class="project-tech">
-            <span>LangChain</span>
-            <span>ChromaDB</span>
-            <span>RAG</span>
-            <span>Python</span>
-          </div>
-        </div>
-
-        <div class="project-item">
-          <h3><a href="https://github.com/soojjung/GOTCHA-FE" target="_blank">Gacha Shop Map Service</a></h3>
-          <p class="project-period">Nov 2025 — Present</p>
-          <ul class="project-desc">
-            <li>Architected a 3-layer architecture with Container/Presenter pattern; hybrid state management (TanStack Query + Zustand) across 21 API hooks.</li>
-            <li>Optimized geospatial performance reducing API overhead by 80% and component complexity by 44%.</li>
-          </ul>
-          <div class="project-tech">
-            <span>React</span>
-            <span>TypeScript</span>
-            <span>Zustand</span>
-            <span>TanStack Query</span>
-          </div>
-        </div>
-
-        <div class="project-item">
-          <h3><a href="https://github.com/soojjung/OppaManyColorTone" target="_blank">Personal Color Self-Diagnosis Service</a></h3>
-          <p class="project-period">Feb 2023 — Aug 2024</p>
-          <ul class="project-desc">
-            <li>Scaled to 77,900+ diagnoses and 27,600+ AAU with 91.5% completion rate.</li>
-            <li>Achieved 83% organic traffic (30,000+ sessions) via SEO/SSR optimization, ranking on Google's first page.</li>
+        <div class="timeline-item">
+          <h3><span data-lang-en>Gacha Shop Map Service</span><span data-lang-ko>가챠샵 지도 서비스</span></h3>
+          <p class="project-link"><a href="https://github.com/soojjung/GOTCHA-FE" target="_blank">github.com/soojjung/GOTCHA-FE</a></p>
+          <p class="period"><span data-lang-en>Dec 2025 — Present</span><span data-lang-ko>2025년 12월 — 현재</span></p>
+          <ul class="description">
+            <li>
+              <span data-lang-en>Architected a 3-layer architecture with Container/Presenter pattern; hybrid state management (TanStack Query + Zustand) across 21 API hooks.</span>
+              <span data-lang-ko>Container/Presenter 패턴 기반 3계층 아키텍처 설계, 21개 API 훅에 걸쳐 하이브리드 상태 관리(TanStack Query + Zustand) 적용</span>
+            </li>
+            <li>
+              <span data-lang-en>Optimized geospatial performance reducing API overhead by 80% through strategic map optimization patterns.</span>
+              <span data-lang-ko>전략적 지도 최적화 패턴 적용으로 지리공간 성능 개선 및 API 오버헤드 80% 감소</span>
+            </li>
+            <li>
+              <span data-lang-en>Reduced component complexity by 44% through hook refactoring and centralized API wrapper with QueryErrorBoundaries.</span>
+              <span data-lang-ko>훅 리팩토링과 QueryErrorBoundaries 기반 중앙화된 API 래퍼 구축으로 컴포넌트 복잡도 44% 감소</span>
+            </li>
           </ul>
           <div class="project-tech">
             <span>React</span>
             <span>Next.js</span>
-            <span>Recoil</span>
-            <span>SEO</span>
+            <span>TypeScript</span>
+            <span>Zustand</span>
+            <span>TanStack Query</span>
+            <span>Tailwind CSS</span>
           </div>
+        </div>
+
+        <div class="timeline-item">
+          <h3><span data-lang-en>RAG-based AI Policy Assistant</span><span data-lang-ko>RAG 기반 AI 정책 도우미</span></h3>
+          <p class="project-link"><a href="https://github.com/soojjung/bbumate-ai" target="_blank">github.com/soojjung/bbumate-ai</a></p>
+          <p class="period"><span data-lang-en>Sep 2025 — Nov 2025</span><span data-lang-ko>2025년 9월 — 2025년 11월</span></p>
+          <ul class="description">
+            <li>
+              <span data-lang-en>Architected an end-to-end RAG pipeline (LangChain + ChromaDB) centralizing 113+ policies; reduced latency 66% via parallel document grading.</span>
+              <span data-lang-ko>LangChain + ChromaDB 기반 엔드투엔드 RAG 파이프라인 구축, 113개 이상 정책 통합 관리 및 병렬 문서 평가로 지연시간 66% 단축</span>
+            </li>
+            <li>
+              <span data-lang-en>Engineered a multi-step fallback strategy (RAG &rarr; Query Re-write &rarr; Web Search) achieving 100% query fulfillment.</span>
+              <span data-lang-ko>RAG &rarr; 쿼리 재작성 &rarr; 웹 검색 순서의 다단계 폴백 전략 설계, 100% 쿼리 처리율 달성</span>
+            </li>
+            <li>
+              <span data-lang-en>Developed a high-reliability grounding system with 97+ URL mappings, ensuring 100% source attribution to official documentation.</span>
+              <span data-lang-ko>97개 이상 URL 매핑 기반 고신뢰 그라운딩 시스템 구축, 모든 AI 응답에 공식 문서 출처 100% 명시</span>
+            </li>
+          </ul>
+          <div class="project-tech">
+            <span>LangChain</span>
+            <span>ChromaDB</span>
+            <span>FastAPI</span>
+            <span>Python</span>
+          </div>
+        </div>
+
+        <div class="timeline-item">
+          <h3><span data-lang-en>Personal Color Self-Diagnosis Service</span><span data-lang-ko>퍼스널 컬러 자가진단 서비스</span></h3>
+          <p class="project-link"><a href="https://github.com/soojjung/OppaManyColorTone" target="_blank">github.com/soojjung/OppaManyColorTone</a></p>
+          <p class="period"><span data-lang-en>Feb 2023 — Aug 2024</span><span data-lang-ko>2023년 2월 — 2024년 8월</span></p>
+          <ul class="description">
+            <li>
+              <span data-lang-en>Engineered a 9-stage algorithm using 36 curated chips with bonus round re-evaluation, ensuring a 100% diagnosis rate.</span>
+              <span data-lang-ko>36개 선별 칩과 보너스 라운드 재평가를 활용한 9단계 알고리즘 설계, 100% 진단율 달성</span>
+            </li>
+            <li>
+              <span data-lang-en>Scaled to 77,900+ diagnoses and 27,600+ AAU with 91.5% completion rate.</span>
+              <span data-lang-ko>77,900회 이상 진단 및 27,600명 이상 AAU 달성, 91.5% 완료율 기록</span>
+            </li>
+            <li>
+              <span data-lang-en>Achieved 83% organic traffic (30,000+ sessions) via SEO/SSR optimization, ranking on Google's first page.</span>
+              <span data-lang-ko>SEO/SSR 최적화로 83% 자연 유입 트래픽(30,000회 이상 세션) 달성, 구글 첫 페이지 노출</span>
+            </li>
+          </ul>
+          <div class="project-tech">
+            <span>React</span>
+            <span>Next.js</span>
+            <span>TypeScript</span>
+            <span>Recoil</span>
+            <span>Styled-components</span>
+            <span>Firebase</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Education -->
+      <section class="cv-section">
+        <h2><span data-lang-en>Education</span><span data-lang-ko>학력</span></h2>
+
+        <div class="timeline-item">
+          <h3><span data-lang-en>BSc. in Applied Mathematics and Statistics &amp; Economics</span><span data-lang-ko>응용수학 및 통계학 &amp; 경제학 학사</span></h3>
+          <p class="company"><span data-lang-en>Stony Brook, State University of New York — 3.57 GPA</span><span data-lang-ko>스토니브룩, 뉴욕주립대학교 — GPA 3.57</span></p>
+          <p class="period"><span data-lang-en>Graduated Dec 2018</span><span data-lang-ko>2018년 12월 졸업</span></p>
+        </div>
+
+        <div class="timeline-item">
+          <h3><span data-lang-en>Backend &amp; AI Engineering Bootcamp</span><span data-lang-ko>백엔드 &amp; AI 엔지니어링 부트캠프</span></h3>
+          <p class="company"><span data-lang-en>FastCampus K-Digital Training</span><span data-lang-ko>패스트캠퍼스 K-Digital Training</span></p>
+          <p class="period"><span data-lang-en>Jun 2025 — Dec 2025</span><span data-lang-ko>2025년 6월 — 2025년 12월</span></p>
+          <ul class="description">
+            <li>
+              <span data-lang-en>Java/Spring Boot backend development, Data Structures &amp; Algorithms, Database Systems, OS &amp; Networks (196h)</span>
+              <span data-lang-ko>Java/Spring Boot 백엔드 개발, 자료구조 &amp; 알고리즘, 데이터베이스, OS &amp; 네트워크 (196h)</span>
+            </li>
+            <li>
+              <span data-lang-en>AI &amp; Machine Learning: Python-based ML workflow, NLP fundamentals, Transformer-based LLMs (BERT, GPT) (34h)</span>
+              <span data-lang-ko>AI &amp; 머신러닝: Python 기반 ML 워크플로우, NLP 기초, Transformer 기반 LLM (BERT, GPT) (34h)</span>
+            </li>
+          </ul>
         </div>
       </section>
 
       <!-- Additional -->
       <section class="cv-section">
-        <h2>Additional</h2>
+        <h2><span data-lang-en>Additional</span><span data-lang-ko>기타 활동</span></h2>
         <ul class="additional-list">
-          <li>Staff Member, TeoConf 2024 (3rd Edition) — Coordinated event logistics and attendee (200+) engagement</li>
-          <li>Google Analytics Certification (GA4)</li>
+          <li>
+            <span data-lang-en>Staff Member, TeoConf 2024 (3rd Edition) — Planned event programs and coordinated logistics for 200+ attendees</span>
+            <span data-lang-ko>TeoConf 2024 (3회) 스태프 — 이벤트 기획 및 200명 이상 참가자 행사 운영 담당</span>
+          </li>
         </ul>
       </section>
     </div>
+
+    <script>
+      function setLang(lang) {
+        document.documentElement.lang = lang;
+        document.querySelectorAll('[data-lang-en]').forEach(function (el) {
+          el.style.display = lang === 'en' ? '' : 'none';
+        });
+        document.querySelectorAll('[data-lang-ko]').forEach(function (el) {
+          el.style.display = lang === 'ko' ? '' : 'none';
+        });
+        localStorage.setItem('cv-lang', lang);
+      }
+
+      function toggleLang() {
+        var current = localStorage.getItem('cv-lang') || 'en';
+        setLang(current === 'en' ? 'ko' : 'en');
+      }
+
+      function downloadPdf() {
+        var lang = localStorage.getItem('cv-lang') || 'en';
+        var filename = lang === 'ko' ? '정수진 이력서' : 'Soojin Jung CV';
+        var container = document.querySelector('.cv-container');
+        document.body.classList.add('pdf-mode');
+
+        // Wait for styles to apply before capturing
+        requestAnimationFrame(function () {
+          html2pdf()
+            .set({
+              margin: [10, 10, 10, 10],
+              filename: filename + '.pdf',
+              image: { type: 'jpeg', quality: 0.98 },
+              html2canvas: { scale: 2, useCORS: true, scrollX: 0, scrollY: 0 },
+              jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+              pagebreak: { before: ['.cv-section-projects'] }
+            })
+            .from(container)
+            .save()
+            .then(function () {
+              document.body.classList.remove('pdf-mode');
+            });
+        });
+      }
+
+      setLang(localStorage.getItem('cv-lang') || 'en');
+    </script>
   </body>
 </html>

--- a/styles/cv.css
+++ b/styles/cv.css
@@ -10,6 +10,10 @@
   --font-sans: "Inter", sans-serif;
 }
 
+html[lang="ko"] * {
+  font-family: "Pretendard", "Inter", sans-serif;
+}
+
 body {
   background-color: var(--bg);
   color: var(--text-primary);
@@ -22,17 +26,48 @@ body {
   margin: 0 auto;
 }
 
+.cv-top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
 .back-link {
   display: inline-block;
   color: var(--text-muted);
   text-decoration: none;
   font-size: 14px;
-  margin-bottom: 1.5rem;
   transition: opacity 0.2s;
 }
 
 .back-link:hover {
   opacity: 0.7;
+}
+
+.top-bar-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.btn-pill {
+  background-color: var(--card-bg);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  padding: 0.3rem 0.75rem;
+  border-radius: 16px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition:
+    border-color 0.2s,
+    color 0.2s;
+}
+
+.btn-pill:hover {
+  border-color: var(--accent);
+  color: var(--accent-dark);
 }
 
 /* Header */
@@ -57,12 +92,26 @@ body {
 }
 
 .cv-header .contact {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  row-gap: 0.35rem;
   font-size: 0.85rem;
   color: var(--text-muted);
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.cv-header .contact > *:nth-child(3n + 1) {
+  text-align: right;
+}
+
+.cv-header .contact > *:nth-child(3n) {
+  text-align: left;
+}
+
+.cv-header .contact .dot {
+  text-align: center;
+  padding: 0 0.5rem;
 }
 
 .cv-header .contact a {
@@ -76,7 +125,7 @@ body {
 
 /* Sections */
 .cv-section {
-  margin-bottom: 2.5rem;
+  margin-bottom: 3.5rem;
 }
 
 .cv-section h2 {
@@ -115,7 +164,7 @@ body {
 }
 
 .timeline-item::before {
-  content: '';
+  content: "";
   position: absolute;
   left: -5px;
   top: 6px;
@@ -154,17 +203,24 @@ body {
 }
 
 /* Skills */
-.skills-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+.skills-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.skill-row {
+  display: flex;
+  align-items: center;
   gap: 1rem;
 }
 
-.skill-category h3 {
+.skill-row h3 {
   font-size: 0.9rem;
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.5rem;
+  white-space: nowrap;
+  min-width: 120px;
 }
 
 .skill-tags {
@@ -182,60 +238,29 @@ body {
   border: 1px solid var(--border);
 }
 
-/* Projects */
-.project-item {
-  background-color: var(--card-bg);
-  border-radius: 8px;
-  padding: 1.25rem;
-  margin-bottom: 1rem;
-  border: 1px solid var(--border);
+/* Project-specific elements inside timeline */
+.project-link {
+  font-size: 0.8rem;
+  margin-bottom: 0.15rem;
 }
 
-.project-item:last-child {
-  margin-bottom: 0;
-}
-
-.project-item h3 {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 0.25rem;
-}
-
-.project-item h3 a {
-  color: var(--text-primary);
+.project-link a {
+  color: var(--accent-dark);
   text-decoration: none;
 }
 
-.project-item h3 a:hover {
+.project-link a:hover {
   text-decoration: underline;
 }
 
-.project-item .project-period {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  margin-bottom: 0.5rem;
-}
-
-.project-item .project-desc {
-  list-style: disc;
-  padding-left: 1.25rem;
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  margin-bottom: 0.5rem;
-}
-
-.project-item .project-desc li {
-  margin-bottom: 0.25rem;
-}
-
-.project-item .project-tech {
+.project-tech {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
+  margin-top: 0.5rem;
 }
 
-.project-item .project-tech span {
+.project-tech span {
   background-color: var(--bg);
   color: var(--accent-dark);
   padding: 0.2rem 0.6rem;
@@ -243,15 +268,26 @@ body {
   font-size: 0.75rem;
 }
 
-/* Print */
+/* Print — page 1: header~경력, page 2: 프로젝트~기타 */
+@page {
+  size: A4;
+  margin: 10mm 12mm;
+}
+
 @media print {
-  body {
-    background-color: #fff;
-    color: #222;
-    padding: 0;
+  * {
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
   }
 
-  .back-link {
+  body {
+    background-color: #fff;
+    padding: 0;
+    font-size: 8pt;
+    line-height: 1.35;
+  }
+
+  .cv-top-bar {
     display: none;
   }
 
@@ -259,69 +295,293 @@ body {
     max-width: 100%;
   }
 
+  /* Header — compact */
+  .cv-header {
+    padding-bottom: 0.6rem;
+    margin-bottom: 0.6rem;
+    border-bottom: 2px solid var(--accent);
+  }
+
   .cv-header h1 {
-    color: #222;
+    font-size: 1.4rem;
+    margin-bottom: 0.1rem;
   }
 
   .cv-header .title {
-    color: #555;
+    font-size: 0.85rem;
+    margin-bottom: 0.35rem;
   }
 
-  .cv-header .contact,
+  .cv-header .contact {
+    font-size: 0.72rem;
+  }
+
   .cv-header .contact a {
-    color: #555;
+    color: var(--text-secondary);
   }
 
-  .cv-header {
-    border-bottom-color: #ccc;
+  /* Sections — tight spacing */
+  .cv-section {
+    margin-bottom: 0.6rem;
   }
 
   .cv-section h2 {
-    color: #555;
-    border-bottom-color: #ddd;
+    font-size: 0.8rem;
+    color: var(--accent);
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.2rem;
+    margin-bottom: 0.4rem;
   }
 
-  .about-text,
-  .timeline-item .description,
-  .project-item .project-desc {
-    color: #333;
+  .about-text {
+    font-size: 0.75rem;
   }
 
+  .additional-list {
+    font-size: 0.75rem;
+  }
+
+  /* Timeline */
   .timeline-item {
-    border-left-color: #ccc;
+    border-left: 2px solid var(--accent);
+    padding-left: 0.8rem;
+    margin-bottom: 0.5rem;
+    break-inside: avoid;
   }
 
   .timeline-item::before {
-    background-color: #ccc;
+    background-color: var(--accent);
+    width: 6px;
+    height: 6px;
+    left: -4px;
+    top: 4px;
   }
 
-  .timeline-item h3,
-  .skill-category h3,
-  .project-item h3 {
-    color: #222;
+  .timeline-item h3 {
+    font-size: 0.8rem;
   }
 
-  .timeline-item .company,
-  .timeline-item .period,
-  .project-item .project-period {
-    color: #666;
+  .timeline-item .company {
+    font-size: 0.72rem;
+    color: var(--accent-dark);
+    margin-bottom: 0.1rem;
+  }
+
+  .timeline-item .period {
+    font-size: 0.65rem;
+    margin-bottom: 0.2rem;
+  }
+
+  .timeline-item .description {
+    font-size: 0.72rem;
+  }
+
+  .timeline-item .description li {
+    margin-bottom: 0.05rem;
+    margin-left: 0.6rem;
+  }
+
+  /* Skills */
+  .skills-list {
+    gap: 0.25rem;
+  }
+
+  .skill-row h3 {
+    font-size: 0.72rem;
+    min-width: 90px;
   }
 
   .skill-tag {
-    background-color: #f5f5f5;
-    color: #333;
-    border-color: #ddd;
+    background-color: var(--card-bg);
+    border: 1px solid var(--border);
+    font-size: 0.65rem;
+    padding: 0.1rem 0.4rem;
   }
 
-  .project-item {
-    background-color: #f9f9f9;
-    border-color: #ddd;
+  /* Page break — Projects starts on page 2 */
+  .cv-section-projects {
+    break-before: page;
   }
 
-  .project-item .project-tech span {
-    background-color: #eee;
-    color: #555;
+  /* Project-specific elements in print */
+  .project-link {
+    font-size: 0.65rem;
+    margin-bottom: 0.05rem;
   }
+
+  .project-link a {
+    color: var(--accent-dark);
+  }
+
+  .project-tech {
+    margin-top: 0.2rem;
+  }
+
+  .project-tech span {
+    background-color: var(--bg);
+    color: var(--accent-dark);
+    font-size: 0.6rem;
+    padding: 0.08rem 0.4rem;
+  }
+}
+
+/* PDF download mode — applied via JS before html2pdf renders */
+.pdf-mode {
+  padding: 0 !important;
+}
+
+.pdf-mode .cv-top-bar {
+  display: none;
+}
+
+.pdf-mode .cv-container {
+  max-width: 100%;
+  margin: 0;
+  padding: 0 12px 0 20px;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.pdf-mode .cv-header {
+  padding-bottom: 18px;
+  margin-bottom: 20px;
+}
+
+.pdf-mode .cv-header h1 {
+  font-size: 28px;
+  margin-bottom: 4px;
+}
+
+.pdf-mode .cv-header .title {
+  font-size: 15px;
+  margin-bottom: 10px;
+}
+
+.pdf-mode .cv-header .contact {
+  font-size: 13px;
+}
+
+.pdf-mode .cv-section {
+  margin-bottom: 32px;
+}
+
+.pdf-mode .cv-section-projects,
+.pdf-mode .cv-section-projects ~ .cv-section {
+  margin-bottom: 26px;
+}
+
+.pdf-mode .cv-section h2 {
+  font-size: 14.5px;
+  padding-bottom: 4px;
+  margin-bottom: 8px;
+}
+
+.pdf-mode .about-text {
+  font-size: 13.5px;
+}
+
+.pdf-mode .additional-list {
+  font-size: 14px;
+  line-height: 2;
+}
+
+.pdf-mode .timeline-item {
+  padding-left: 14px;
+  margin-bottom: 14px;
+}
+
+.pdf-mode .timeline-item::before {
+  width: 8px;
+  height: 8px;
+  left: -5px;
+  top: 6px;
+}
+
+.pdf-mode .timeline-item h3 {
+  font-size: 15px;
+}
+
+.pdf-mode .timeline-item .company {
+  font-size: 13.5px;
+  margin-bottom: 3px;
+}
+
+.pdf-mode .timeline-item .period {
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+
+.pdf-mode .timeline-item .description {
+  font-size: 13.5px;
+}
+
+.pdf-mode .timeline-item .description li {
+  margin-bottom: 3px;
+  margin-left: 12px;
+}
+
+.pdf-mode .skills-list {
+  gap: 12px;
+}
+
+.pdf-mode .skill-row h3 {
+  font-size: 13.5px;
+  min-width: 110px;
+}
+
+.pdf-mode .skill-tag {
+  font-size: 12px;
+  padding: 3px 10px;
+}
+
+/* Page 2 — projects & additional: larger sizing */
+.pdf-mode .cv-section-projects {
+  margin-bottom: 26px;
+}
+
+.pdf-mode .cv-section-projects .timeline-item {
+  margin-bottom: 14px;
+}
+
+.pdf-mode .cv-section-projects .timeline-item h3 {
+  font-size: 16px;
+}
+
+.pdf-mode .cv-section-projects .timeline-item .description {
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.pdf-mode .cv-section-projects .timeline-item .description li {
+  margin-bottom: 4px;
+}
+
+.pdf-mode .cv-section-projects .project-link {
+  font-size: 12.5px;
+  margin-bottom: 3px;
+}
+
+.pdf-mode .cv-section-projects .project-tech {
+  margin-top: 10px;
+}
+
+.pdf-mode .cv-section-projects .project-tech span {
+  font-size: 11.5px;
+  padding: 3px 9px;
+}
+
+.pdf-mode .project-link {
+  font-size: 12px;
+  margin-bottom: 3px;
+}
+
+.pdf-mode .project-tech {
+  margin-top: 8px;
+}
+
+.pdf-mode .project-tech span {
+  font-size: 11px;
+  padding: 3px 8px;
 }
 
 /* Responsive */
@@ -331,11 +591,24 @@ body {
   }
 
   .cv-header .contact {
-    flex-direction: column;
+    grid-template-columns: 1fr;
+    text-align: center;
     gap: 0.3rem;
+    max-width: 100%;
   }
 
-  .skills-grid {
-    grid-template-columns: 1fr;
+  .cv-header .contact > *:nth-child(3n + 1),
+  .cv-header .contact > *:nth-child(3n) {
+    text-align: center;
+  }
+
+  .cv-header .contact .dot {
+    display: none;
+  }
+
+  .skill-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
   }
 }


### PR DESCRIPTION
- Add bilingual (EN/KO) support with language toggle and localStorage persistence
- Add PDF download via html2pdf.js with page break and pdf-mode styling
- Add Pretendard font for Korean text
- Update work experience with achievement-oriented bullet points
- Add tech stack tags to work experience and projects (synced with GitHub repos)
- Reorganize sections: About → Skills → Experience → Projects → Education → Additional
- Add contact info grid layout with symmetric dot separators
- Add Tools skill row (AWS, Google Analytics, GitHub Actions)
- Add bootcamp curriculum description
- Fix responsive grid layout for mobile contact section