### PR TITLE
feat: switch CV to monochrome theme and refine content

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -88,7 +88,10 @@
             GA4/Mixpanel analytics and established code review processes that
             measurably improved quality. Recently expanded into backend and AI
             engineering — building RAG pipelines, REST APIs, and CI/CD workflows
-            — to deliver end-to-end solutions.</span
+            — to deliver end-to-end solutions. Actively integrating AI into the
+            development workflow — building project-wide context systems and
+            custom automation commands to leverage AI as a design review
+            partner, not just a code generator.</span
           >
           <span data-lang-ko
             >핀테크 및 AI 분야에서 3년 이상의 프론트엔드 개발 경험을 바탕으로
@@ -98,7 +101,9 @@
             의사결정과 코드 리뷰 프로세스 도입으로 품질을 개선한 경험이
             있습니다. 최근에는 백엔드 및 AI 엔지니어링으로 영역을 확장하여 RAG
             파이프라인, REST API, CI/CD 워크플로우 등 엔드투엔드 솔루션을
-            제공하고 있습니다.</span
+            제공하고 있습니다. 프로젝트 컨텍스트 시스템과 커스텀 자동화 커맨드를
+            구축하여 AI를 단순 코드 생성이 아닌 설계 검토 파트너로 활용하는 데
+            관심을 두고 있습니다.</span
           >
         </p>
       </section>
@@ -209,8 +214,8 @@
             </li>
           </ul>
           <div class="project-tech">
-            <span>React</span>
             <span>JavaScript</span>
+            <span>React</span>
             <span>Recoil</span>
             <span>Tailwind CSS</span>
             <span>Zod</span>
@@ -265,8 +270,8 @@
             </li>
           </ul>
           <div class="project-tech">
-            <span>React</span>
             <span>JavaScript</span>
+            <span>React</span>
             <span>Context API</span>
             <span>Styled-components</span>
           </div>
@@ -317,14 +322,14 @@
               >
             </li>
             <li data-lang-ko>
-              훅 리팩토링과 QueryErrorBoundaries 기반 중앙화된 API 래퍼 구축으로
-              컴포넌트 복잡도 44% 감소
+              AI 컨텍스트 시스템(.ai/)으로 아키텍처·코딩 표준 문서를 관리, AI를
+              설계 검토 파트너로 활용하여 컨벤션 일관성 확보
             </li>
           </ul>
           <div class="project-tech">
+            <span>TypeScript</span>
             <span>React</span>
             <span>Next.js</span>
-            <span>TypeScript</span>
             <span>Zustand</span>
             <span>TanStack Query</span>
             <span>Tailwind CSS</span>
@@ -333,8 +338,8 @@
 
         <div class="timeline-item">
           <h3>
-            <span data-lang-en>RAG-based AI Policy Assistant</span
-            ><span data-lang-ko>RAG 기반 AI 정책 도우미</span>
+            <span data-lang-en>RAG-based AI Policy Assistant for Newlyweds</span
+            ><span data-lang-ko>RAG 기반 신혼부부 정책 AI 도우미</span>
           </h3>
           <p class="project-link">
             <a href="https://github.com/soojjung/bbumate-ai" target="_blank"
@@ -374,10 +379,10 @@
             </li>
           </ul>
           <div class="project-tech">
+            <span>Python</span>
+            <span>FastAPI</span>
             <span>LangChain</span>
             <span>ChromaDB</span>
-            <span>FastAPI</span>
-            <span>Python</span>
           </div>
         </div>
 
@@ -405,7 +410,7 @@
               >
               <span data-lang-ko
                 >36개 선별 칩과 보너스 라운드 재평가를 활용한 9단계 알고리즘
-                설계, 100% 진단율 달성</span
+                설계</span
               >
             </li>
             <li>
@@ -419,14 +424,13 @@
               >
             </li>
             <li data-lang-ko>
-              SEO/SSR 최적화로 83% 자연 유입 트래픽(30,000회 이상 세션) 달성,
-              구글 첫 페이지 노출
+              SEO/SSR 최적화로 83% 자연 유입 트래픽 달성, 구글 첫 페이지 노출
             </li>
           </ul>
           <div class="project-tech">
+            <span>TypeScript</span>
             <span>React</span>
             <span>Next.js</span>
-            <span>TypeScript</span>
             <span>Recoil</span>
             <span>Styled-components</span>
             <span>Firebase</span>

--- a/styles/cv.css
+++ b/styles/cv.css
@@ -1,13 +1,13 @@
 :root {
-  --accent: #ff3801;
-  --accent-dark: #e63200;
-  --accent-light: rgba(255, 56, 1, 0.08);
+  --accent: #222222;
+  --accent-dark: #1a1a1a;
+  --accent-light: #f3f3f3;
   --bg: #ffffff;
   --card-bg: #ffffff;
   --text-primary: #1a1a1a;
   --text-secondary: #444444;
   --text-muted: #999999;
-  --border: #eaeaea;
+  --border: #e0e0e0;
   --font-sans: "Inter", sans-serif;
 }
 
@@ -17,7 +17,7 @@ html[lang="ko"] * {
 
 ::selection {
   color: #ffffff;
-  background: var(--accent);
+  background: #222222;
 }
 
 body {


### PR DESCRIPTION
- Replace orange accent with monochrome (#222222) color scheme
- Unify tech tag order: language → framework → state mgmt → styling → tools
- Add AI context system bullet to Gacha Shop project (KO only)
- Add AI workflow mention to About section (EN/KO)
- Remove English bootcamp descriptions and reduce EN project bullets to 2
- Rename RAG project to include "for Newlyweds"
- Trim redundant details from Personal Color project